### PR TITLE
Cleaner meshoptimizer usage

### DIFF
--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -473,11 +473,6 @@ void Scene::buildGeometryClusters(ProcessingInfo& processingInfo, Geometry& geom
   }
   else
   {
-    // first sort for vcache
-    std::vector<glm::uvec3> triangles = geometry.triangles;
-    meshopt_optimizeVertexCache((uint32_t*)geometry.triangles.data(), (uint32_t*)triangles.data(), triangles.size() * 3,
-                                geometry.numVertices);
-
     // we allow smaller clusters to be generated when that significantly improves their bounds
     size_t minTriangles = (m_config.clusterTriangles / 4) & ~3;
 
@@ -490,12 +485,12 @@ void Scene::buildGeometryClusters(ProcessingInfo& processingInfo, Geometry& geom
             meshopt_buildMeshletsFlex(meshlets.data(), geometry.clusterLocalVertices.data(),
                                       geometry.clusterLocalTriangles.data(), (uint32_t*)geometry.triangles.data(),
                                       geometry.triangles.size() * 3, (float*)geometry.positions.data(),
-                                      geometry.numVertices, sizeof(glm::vec3), std::min(255u, m_config.clusterVertices),
-                                      minTriangles, m_config.clusterTriangles, 0.0f, 2.0) :
+                                      geometry.numVertices, sizeof(glm::vec3), m_config.clusterVertices,
+                                      minTriangles, m_config.clusterTriangles, 0.0f, 2.0f) :
             meshopt_buildMeshletsSpatial(meshlets.data(), geometry.clusterLocalVertices.data(),
                                          geometry.clusterLocalTriangles.data(), (uint32_t*)geometry.triangles.data(),
                                          geometry.triangles.size() * 3, (float*)geometry.positions.data(),
-                                         geometry.numVertices, sizeof(glm::vec3), std::min(255u, m_config.clusterVertices),
+                                         geometry.numVertices, sizeof(glm::vec3), m_config.clusterVertices,
                                          minTriangles, m_config.clusterTriangles, m_config.clusterMeshoptSpatialFill);
 
     geometry.numClusters = uint32_t(numClusters);


### PR DESCRIPTION
- We don't need optimizeVertexCache; when using spatial builder it's a no-op as the input triangle order doesn't matter
- As of meshoptimizer 0.23, max_vertices has an upper bound of 256, so we don't need to clamp it.